### PR TITLE
ci(test): retry because some tests are flaky

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,4 +33,5 @@ jobs:
         with:
           tool: cargo-nextest,just
 
-      - run: just test
+      # cmd::build::build_implicit_pinned_and_unpinned is flaky under ubuntu
+      - run: just test --retries 2


### PR DESCRIPTION
I don't have a linux env to properly test, so I am accepting this
flakiness for now.