### PR TITLE
Docs: rbs and toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ json = "0.21.0" # The leading v is not necessary
 python = "master"
 typescript = { ref = "0.21.0", cmd = "make" }
 toml = { ref = "v0.7.0", from = "https://github.com/tree-sitter-grammars/tree-sitter-toml" }
+rbs = { ref = "v0.2.2", from = "https://github.com/joker1007/tree-sitter-rbs" }
 cobol = { ref = "6a469068cacb5e3955bb16ad8dfff0dd792883c9", from = "https://github.com/yutaro-sakamoto/tree-sitter-cobol" }
 ```
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ java = "v0.21.0"
 json = "0.21.0" # The leading v is not necessary
 python = "master"
 typescript = { ref = "0.21.0", cmd = "make" }
+toml = { ref = "v0.7.0", from = "https://github.com/tree-sitter-grammars/tree-sitter-toml" }
 cobol = { ref = "6a469068cacb5e3955bb16ad8dfff0dd792883c9", from = "https://github.com/yutaro-sakamoto/tree-sitter-cobol" }
 ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@
 //! python = "master"
 //! typescript = { ref = "0.21.0", cmd = "make" }
 //! toml = { ref = "v0.7.0", from = "https://github.com/tree-sitter-grammars/tree-sitter-toml" }
+//! rbs = { ref = "v0.2.2", from = "https://github.com/joker1007/tree-sitter-rbs" }
 //! cobol = { ref = "6a469068cacb5e3955bb16ad8dfff0dd792883c9", from = "https://github.com/yutaro-sakamoto/tree-sitter-cobol" }
 //! ```
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@
 //! json = "0.21.0" # The leading v is not necessary
 //! python = "master"
 //! typescript = { ref = "0.21.0", cmd = "make" }
+//! toml = { ref = "v0.7.0", from = "https://github.com/tree-sitter-grammars/tree-sitter-toml" }
 //! cobol = { ref = "6a469068cacb5e3955bb16ad8dfff0dd792883c9", from = "https://github.com/yutaro-sakamoto/tree-sitter-cobol" }
 //! ```
 //!

--- a/tests/cmd/build.rs
+++ b/tests/cmd/build.rs
@@ -182,6 +182,7 @@ fn no_config_should_build_valid_parser_from_head(#[case] languages: Vec<&str>) {
 
 #[rstest]
 #[case::pinned_hash_and_from_cobol("cobol", "6a46906")]
+#[case::pinned_from_toml("toml", "v0.7.0")]
 #[case::pinned_leading_v_java("java", "v0.21.0")]
 #[case::pinned_master_python("python", "master")]
 #[case::pinned_no_leading_v_json("json", "v0.21.0")]
@@ -195,6 +196,7 @@ fn build_explicit_pinned_and_unpinned(#[case] language: &str, #[case] version: &
         json = "0.21.0"
         python = "master"
         typescript = { ref = "0.21.0", cmd = "make" }
+        toml = { ref = "v0.7.0", from = "https://github.com/tree-sitter-grammars/tree-sitter-toml" }
         cobol = { ref = "6a469068cacb5e3955bb16ad8dfff0dd792883c9", from = "https://github.com/yutaro-sakamoto/tree-sitter-cobol" }
       "#
     };
@@ -226,6 +228,7 @@ fn build_implicit_pinned_and_unpinned() {
         ("java", "v0.21.0"),
         ("python", "master"),
         ("json", "v0.21.0"),
+        ("toml", "v0.7.0"),
         ("typescript", "v0.21.0"),
     ];
     let config = indoc! {
@@ -235,6 +238,7 @@ fn build_implicit_pinned_and_unpinned() {
         json = "0.21.0"
         python = "master"
         typescript = { ref = "0.21.0", cmd = "make" }
+        toml = { ref = "v0.7.0", from = "https://github.com/tree-sitter-grammars/tree-sitter-toml" }
         cobol = { ref = "6a469068cacb5e3955bb16ad8dfff0dd792883c9", from = "https://github.com/yutaro-sakamoto/tree-sitter-cobol" }
       "#
     };

--- a/tests/cmd/build.rs
+++ b/tests/cmd/build.rs
@@ -183,6 +183,7 @@ fn no_config_should_build_valid_parser_from_head(#[case] languages: Vec<&str>) {
 #[rstest]
 #[case::pinned_hash_and_from_cobol("cobol", "6a46906")]
 #[case::pinned_from_toml("toml", "v0.7.0")]
+#[case::pinned_from_rbs("rbs", "v0.2.2")]
 #[case::pinned_leading_v_java("java", "v0.21.0")]
 #[case::pinned_master_python("python", "master")]
 #[case::pinned_no_leading_v_json("json", "v0.21.0")]
@@ -197,6 +198,7 @@ fn build_explicit_pinned_and_unpinned(#[case] language: &str, #[case] version: &
         python = "master"
         typescript = { ref = "0.21.0", cmd = "make" }
         toml = { ref = "v0.7.0", from = "https://github.com/tree-sitter-grammars/tree-sitter-toml" }
+        rbs = { ref = "v0.2.2", from = "https://github.com/joker1007/tree-sitter-rbs" }
         cobol = { ref = "6a469068cacb5e3955bb16ad8dfff0dd792883c9", from = "https://github.com/yutaro-sakamoto/tree-sitter-cobol" }
       "#
     };
@@ -228,6 +230,7 @@ fn build_implicit_pinned_and_unpinned() {
         ("java", "v0.21.0"),
         ("python", "master"),
         ("json", "v0.21.0"),
+        ("rbs", "v0.2.2"),
         ("toml", "v0.7.0"),
         ("typescript", "v0.21.0"),
     ];
@@ -239,6 +242,7 @@ fn build_implicit_pinned_and_unpinned() {
         python = "master"
         typescript = { ref = "0.21.0", cmd = "make" }
         toml = { ref = "v0.7.0", from = "https://github.com/tree-sitter-grammars/tree-sitter-toml" }
+        rbs = { ref = "v0.2.2", from = "https://github.com/joker1007/tree-sitter-rbs" }
         cobol = { ref = "6a469068cacb5e3955bb16ad8dfff0dd792883c9", from = "https://github.com/yutaro-sakamoto/tree-sitter-cobol" }
       "#
     };


### PR DESCRIPTION
## Description

The toml tree-sitter grammar is maintained under the tree-sitter-grammars org, not the default tree-sitter org - pinned at v0.7.0.

The rbs tree-sitter grammar is maintained by @joker1007, not the default tree-sitter org - pinned at v0.2.2.

Add toml and rbs as a documented examples of the `from` override in README, rustdoc, and test fixtures.

## Motivation and Context

Just adds documentation and test support for toml and rbs grammars, since they are becoming more widely used in Ruby-land. ;)

I have also integrated tsdl into my [ts-grammar-action](https://github.com/kettle-rb/ts-grammar-action), so it now downloads released version of tsdl, and uses it to install grammars! I am now beginning use that GitHub Action in at least one [workflow](https://github.com/kettle-rb/kettle-jem/blob/main/template/.github/workflows/templating.yml.example#L53) in all of my gems, as I begin validating their coherence with my gem template, and they will use tree sitter grammars to accomplish much of that work via my [ast-merge](https://github.com/kettle-rb/ast-merge) gem & friends. in other words - **all of my gems will depend on this in GHA soon**.

## How Has This Been Tested?

Both grammars built and verified successfully:
• toml v0.7.0 → libtree-sitter-toml.so (37K) — exports tree_sitter_toml + external scanner symbols
• rbs v0.2.2 → libtree-sitter-rbs.so (129K) — exports tree_sitter_rbs

Total build time: 2.3s (including tree-sitter-cli download). The from overrides for both non-standard repos (tree-sitter-grammars/tree-sitter-toml and joker1007/tree-sitter-rbs) work correctly.

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!--- Thank you for contributing to tsdl!  -->
